### PR TITLE
Expand environment to support metaworld success, segmentation mask, and robot state

### DIFF
--- a/cfgs/config.yaml
+++ b/cfgs/config.yaml
@@ -30,6 +30,7 @@ experiment: exp
 # agent
 lr: 1e-4
 feature_dim: 50
+using_metaworld: false
 
 agent:
   _target_: drqv2.DrQV2Agent

--- a/cfgs/task/metaworld.yaml
+++ b/cfgs/task/metaworld.yaml
@@ -5,3 +5,4 @@ agent:
   reconstruction_loss_coeff: 0.0 # Controls balance between critic and decoder on encoder gradient updates
   backprop_decoder_loss_to_encoder: false
   decoder_lr: 1e-4
+using_metaworld: true

--- a/drqv2.py
+++ b/drqv2.py
@@ -252,6 +252,7 @@ class DrQV2Agent:
         self.critic.train(training)
 
     def act(self, obs, step, eval_mode):
+        obs = obs["pixels"]
         obs = torch.as_tensor(obs, device=self.device)
         obs = self.encoder(obs.unsqueeze(0))
         stddev = utils.schedule(self.stddev_schedule, step)
@@ -369,7 +370,11 @@ class DrQV2Agent:
             return metrics
 
         batch = next(replay_iter)
-        obs, action, reward, discount, next_obs = utils.to_torch(batch, self.device)
+        obs, action, reward, discount, next_obs = batch
+        obs = obs["pixels"]
+        obs, action, reward, discount, next_obs = utils.to_torch(
+            (obs, action, reward, discount, next_obs), self.device
+        )
 
         # augment
         obs = self.aug(obs.float())

--- a/drqv2.py
+++ b/drqv2.py
@@ -372,6 +372,7 @@ class DrQV2Agent:
         batch = next(replay_iter)
         obs, action, reward, discount, next_obs = batch
         obs = obs["pixels"]
+        next_obs = next_obs["pixels"]
         obs, action, reward, discount, next_obs = utils.to_torch(
             (obs, action, reward, discount, next_obs), self.device
         )

--- a/replay_buffer.py
+++ b/replay_buffer.py
@@ -6,7 +6,7 @@ import datetime
 import io
 import random
 import traceback
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 
 import numpy as np
 import torch

--- a/train.py
+++ b/train.py
@@ -102,13 +102,13 @@ class Workspace:
             reward_spec = specs.Array((1,), np.float32, "reward")
 
         discount_spec = specs.Array((1,), np.float32, "discount")
-        self.replay_storage = ReplayBufferStorage(
-            self.train_env.observation_spec(),
-            self.train_env.action_spec(),
-            reward_spec,
-            discount_spec,
-            self.work_dir / "buffer",
-        )
+        data_specs = {
+            "observation": self.train_env.observation_spec(),
+            "action": self.train_env.action_spec(),
+            "reward": reward_spec,
+            "discount": discount_spec,
+        }
+        self.replay_storage = ReplayBufferStorage(data_specs, self.work_dir / "buffer")
 
         self.replay_loader = make_replay_loader(
             self.work_dir / "buffer",

--- a/wrappers.py
+++ b/wrappers.py
@@ -87,6 +87,7 @@ class FrameStackWrapper(dm_env.Environment):
             assert key in wrapped_obs_spec
 
             frame_shape = wrapped_obs_spec[key].shape
+            frame_dtype = wrapped_obs_spec[key].dtype
             # remove batch dim
             if len(frame_shape) == 4:
                 frame_shape = frame_shape[1:]
@@ -94,7 +95,7 @@ class FrameStackWrapper(dm_env.Environment):
                 shape=np.concatenate(
                     [[frame_shape[2] * num_frames], frame_shape[:2]], axis=0
                 ),
-                dtype=np.uint8,
+                dtype=frame_dtype,
                 minimum=0,
                 maximum=255,
                 name="observation",

--- a/wrappers.py
+++ b/wrappers.py
@@ -30,21 +30,35 @@ class ExtendedTimeStep(NamedTuple):
 
 
 class ActionRepeatWrapper(dm_env.Environment):
-    def __init__(self, env, num_repeats):
+    def __init__(self, env, num_repeats, use_metaworld_reward_dict=False):
         self._env = env
         self._num_repeats = num_repeats
+        self.use_metaworld_reward_dict = use_metaworld_reward_dict
 
     def step(self, action):
-        reward = 0.0
-        discount = 1.0
-        for i in range(self._num_repeats):
-            time_step = self._env.step(action)
-            reward += (time_step.reward or 0.0) * discount
-            discount *= time_step.discount
-            if time_step.last():
-                break
-
-        return time_step._replace(reward=reward, discount=discount)
+        if self.use_metaworld_reward_dict:
+            reward = 0.0
+            success = False
+            discount = 1.0
+            for i in range(self._num_repeats):
+                time_step = self._env.step(action)
+                reward += (time_step.reward["reward"] or 0.0) * discount
+                success = success or time_step.reward["success"]
+                discount *= time_step.discount
+                if time_step.last():
+                    break
+            reward_dict = {"reward": reward, "success": success}
+            return time_step._replace(reward=reward_dict, discount=discount)
+        else:
+            reward = 0.0
+            discount = 1.0
+            for i in range(self._num_repeats):
+                time_step = self._env.step(action)
+                reward += (time_step.reward or 0.0) * discount
+                discount *= time_step.discount
+                if time_step.last():
+                    break
+            return time_step._replace(reward=reward, discount=discount)
 
     def observation_spec(self):
         return self._env.observation_spec()
@@ -60,36 +74,43 @@ class ActionRepeatWrapper(dm_env.Environment):
 
 
 class FrameStackWrapper(dm_env.Environment):
-    def __init__(self, env, num_frames, pixels_key="pixels"):
+    def __init__(self, env, num_frames, frame_keys=["pixels"]):
         self._env = env
         self._num_frames = num_frames
-        self._frames = deque([], maxlen=num_frames)
-        self._pixels_key = pixels_key
+        if not isinstance(frame_keys, list):
+            frame_keys = [frame_keys]
+        self._frame_keys = frame_keys
+        self._frames = [deque([], maxlen=num_frames) for _ in range(len(frame_keys))]
 
         wrapped_obs_spec = env.observation_spec()
-        assert pixels_key in wrapped_obs_spec
+        for key in frame_keys:
+            assert key in wrapped_obs_spec
 
-        pixels_shape = wrapped_obs_spec[pixels_key].shape
-        # remove batch dim
-        if len(pixels_shape) == 4:
-            pixels_shape = pixels_shape[1:]
-        self._obs_spec = specs.BoundedArray(
-            shape=np.concatenate(
-                [[pixels_shape[2] * num_frames], pixels_shape[:2]], axis=0
-            ),
-            dtype=np.uint8,
-            minimum=0,
-            maximum=255,
-            name="observation",
-        )
+            frame_shape = wrapped_obs_spec[key].shape
+            # remove batch dim
+            if len(frame_shape) == 4:
+                frame_shape = frame_shape[1:]
+            wrapped_obs_spec[key] = specs.BoundedArray(
+                shape=np.concatenate(
+                    [[frame_shape[2] * num_frames], frame_shape[:2]], axis=0
+                ),
+                dtype=np.uint8,
+                minimum=0,
+                maximum=255,
+                name="observation",
+            )
+        self._obs_spec = wrapped_obs_spec
 
     def _transform_observation(self, time_step):
-        assert len(self._frames) == self._num_frames
-        obs = np.concatenate(list(self._frames), axis=0)
+        obs = time_step.observation
+        for i, key in enumerate(self._frame_keys):
+            assert len(self._frames[i]) == self._num_frames
+            stacked_frames = np.concatenate(list(self._frames[i]), axis=0)
+            obs[key] = stacked_frames
         return time_step._replace(observation=obs)
 
-    def _extract_pixels(self, time_step):
-        pixels = time_step.observation[self._pixels_key]
+    def _extract_pixels(self, time_step, key):
+        pixels = time_step.observation[key]
         # remove batch dim
         if len(pixels.shape) == 4:
             pixels = pixels[0]
@@ -97,15 +118,17 @@ class FrameStackWrapper(dm_env.Environment):
 
     def reset(self):
         time_step = self._env.reset()
-        pixels = self._extract_pixels(time_step)
-        for _ in range(self._num_frames):
-            self._frames.append(pixels)
+        for i, key in enumerate(self._frame_keys):
+            pixels = self._extract_pixels(time_step, key)
+            for _ in range(self._num_frames):
+                self._frames[i].append(pixels)
         return self._transform_observation(time_step)
 
     def step(self, action):
         time_step = self._env.step(action)
-        pixels = self._extract_pixels(time_step)
-        self._frames.append(pixels)
+        for i, key in enumerate(self._frame_keys):
+            pixels = self._extract_pixels(time_step, key)
+            self._frames[i].append(pixels)
         return self._transform_observation(time_step)
 
     def observation_spec(self):
@@ -148,8 +171,9 @@ class ActionDTypeWrapper(dm_env.Environment):
 
 
 class ExtendedTimeStepWrapper(dm_env.Environment):
-    def __init__(self, env):
+    def __init__(self, env, using_metaworld=False):
         self._env = env
+        self.using_metaworld = using_metaworld
 
     def reset(self):
         time_step = self._env.reset()
@@ -163,11 +187,17 @@ class ExtendedTimeStepWrapper(dm_env.Environment):
         if action is None:
             action_spec = self.action_spec()
             action = np.zeros(action_spec.shape, dtype=action_spec.dtype)
+        if time_step.reward is None and self.using_metaworld:
+            reward = {"reward": 0.0, "success": 0}
+        elif time_step.reward is None:
+            reward = 0.0
+        else:
+            reward = time_step.reward
         return ExtendedTimeStep(
             observation=time_step.observation,
             step_type=time_step.step_type,
             action=action,
-            reward=time_step.reward or 0.0,
+            reward=reward,
             discount=time_step.discount or 1.0,
         )
 


### PR DESCRIPTION
Expand the metaworld dm environment to support metaworld success (added to the reward return), as well as a segmentation mask and robot proprioceptive state (added to the observation). Adjust the replay buffer to handle observations and rewards that are nested dictionaries. Adjust the environment wrappers to support the additional information being added to reward and observation. Log the mean, max, and last success for a given evaluation episode.